### PR TITLE
Resolve VS analyzer warnings and messages

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -20,5 +20,5 @@ branches:
     - feature
     - support
     - hotfix
-next-version: "1.0"
+next-version: "1.1"
 

--- a/Solutions/Corvus.UriTemplate.Benchmarking/Corvus.UriTemplate.Benchmarking.csproj
+++ b/Solutions/Corvus.UriTemplate.Benchmarking/Corvus.UriTemplate.Benchmarking.csproj
@@ -9,6 +9,11 @@
 		<IsPackable>false</IsPackable>
 		<DebugType>pdbonly</DebugType>
 		<DebugSymbols>true</DebugSymbols>
+
+    <!--
+    CA1822 - static all the things. Not helpful in benchmark projects where many things are invoked through invisible means.
+    -->
+    <NoWarn>$(NoWarn);CA1822</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Solutions/Corvus.UriTemplate.Benchmarking/UriTemplateParameterExtraction.cs
+++ b/Solutions/Corvus.UriTemplate.Benchmarking/UriTemplateParameterExtraction.cs
@@ -60,10 +60,13 @@ public class UriTemplateParameterExtraction
     /// <summary>
     /// Extract parameters from a URI template using the Corvus implementation of the Tavis API.
     /// </summary>
+    /// <returns>
+    /// A result, to ensure that the code under test does not get optimized out of existence.
+    /// </returns>
     [Benchmark]
-    public void ExtractParametersCorvusTavis()
+    public IDictionary<string, object?>? ExtractParametersCorvusTavis()
     {
-        IDictionary<string, object?>? result = this.corvusTavisTemplate!.GetParameters(TavisUri);
+        return this.corvusTavisTemplate!.GetParameters(TavisUri);
     }
 
     /// <summary>
@@ -83,7 +86,9 @@ public class UriTemplateParameterExtraction
             // We can't use the state
         }
 
+#pragma warning disable RCS1163 // Unused parameter.
         static void HandleParameters(ReadOnlySpan<char> name, ReadOnlySpan<char> value, ref int state)
+#pragma warning restore RCS1163 // Unused parameter.
         {
             state++;
         }
@@ -98,7 +103,9 @@ public class UriTemplateParameterExtraction
         int state = 0;
         this.corvusTemplate!.ParseUri(Uri, HandleParameterMatching, ref state);
 
+#pragma warning disable RCS1163 // Unused parameter.
         static void HandleParameterMatching(bool reset, ReadOnlySpan<char> name, ReadOnlySpan<char> value, ref int state)
+#pragma warning restore RCS1163 // Unused parameter.
         {
             if (reset)
             {

--- a/Solutions/Corvus.UriTemplate.Benchmarking/UriTemplateParameterSetting.cs
+++ b/Solutions/Corvus.UriTemplate.Benchmarking/UriTemplateParameterSetting.cs
@@ -72,7 +72,9 @@ public class UriTemplateParameterSetting
     {
         object? nullState = default;
         JsonUriTemplateResolver.TryResolveResult(UriTemplate.AsSpan(), false, this.jsonValues.RootElement, HandleResult, ref nullState);
+#pragma warning disable RCS1163 // Unused parameter.
         static void HandleResult(ReadOnlySpan<char> resolvedTemplate, ref object? state)
+#pragma warning restore RCS1163 // Unused parameter.
         {
             // NOP
         }
@@ -86,7 +88,9 @@ public class UriTemplateParameterSetting
     {
         object? nullState = default;
         DictionaryUriTemplateResolver.TryResolveResult(UriTemplate.AsSpan(), false, Parameters, HandleResult, ref nullState);
+#pragma warning disable RCS1163 // Unused parameter.
         static void HandleResult(ReadOnlySpan<char> resolvedTemplate, ref object? state)
+#pragma warning restore RCS1163 // Unused parameter.
         {
             // NOP
         }

--- a/Solutions/Corvus.UriTemplate.Benchmarking/packages.lock.json
+++ b/Solutions/Corvus.UriTemplate.Benchmarking/packages.lock.json
@@ -4,49 +4,47 @@
     "net7.0": {
       "BenchmarkDotNet": {
         "type": "Direct",
-        "requested": "[0.13.2, )",
-        "resolved": "0.13.2",
-        "contentHash": "82IflYxY8qnQXEA3kXtqC9pntrkJYJZbQ9PV7hEV/XcfCtOdwLz84ilyO8tLRVbiliWttvmt/v44P+visN+fPQ==",
+        "requested": "[0.13.4, )",
+        "resolved": "0.13.4",
+        "contentHash": "P6avThzS0HRJEjcCfnJdaMIujCMBoWQXSJiVYYFtMltrVeEMaIhg7r5qiGPyx9O2ZXuNpqIxVEg1JqgvfwnI2Q==",
         "dependencies": {
-          "BenchmarkDotNet.Annotations": "0.13.2",
+          "BenchmarkDotNet.Annotations": "0.13.4",
           "CommandLineParser": "2.4.3",
+          "Gee.External.Capstone": "2.3.0",
           "Iced": "1.17.0",
           "Microsoft.CodeAnalysis.CSharp": "3.0.0",
           "Microsoft.Diagnostics.Runtime": "2.2.332302",
           "Microsoft.Diagnostics.Tracing.TraceEvent": "3.0.2",
           "Microsoft.DotNet.PlatformAbstractions": "3.1.6",
           "Perfolizer": "0.2.1",
-          "System.Management": "6.0.0",
-          "System.Reflection.Emit": "4.7.0",
-          "System.Reflection.Emit.Lightweight": "4.7.0",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Management": "6.0.0"
         }
       },
       "BenchmarkDotNet.Diagnostics.Windows": {
         "type": "Direct",
-        "requested": "[0.13.2, )",
-        "resolved": "0.13.2",
-        "contentHash": "COcdJcVt036U8cYHyHhq5ymI24AoV5h5BKHBzl5fbY0PUWF32immWWnSd66taOJRoe0Fr5ikimHNBVNXgV3KqA==",
+        "requested": "[0.13.4, )",
+        "resolved": "0.13.4",
+        "contentHash": "psb/LnKJyKGSJKwfzpqdYxqV/SrcMie9BBzFGqyPrdO7LmJeZjicIbxrEIF1EkGjWK/ug89clr4gp/V5OWsxxA==",
         "dependencies": {
-          "BenchmarkDotNet": "0.13.2",
+          "BenchmarkDotNet": "0.13.4",
           "Microsoft.Diagnostics.Tracing.TraceEvent": "3.0.2"
         }
       },
       "Endjin.RecommendedPractices.GitHub": {
         "type": "Direct",
-        "requested": "[2.1.2, )",
-        "resolved": "2.1.2",
-        "contentHash": "mBUCmeSdWWrIQKuuYd9zflcwupRDmpF39dsbb07e6azlNIQqaE1J5TQa17c3SFVRXn9IZrClsmKoMporRTAWwQ==",
+        "requested": "[2.1.4, )",
+        "resolved": "2.1.4",
+        "contentHash": "SUBvnwWuKtklIv9NWqY9PI/J1nONyvcOlitIhUTq5Hk8K0QnBoISc1xTZTe0C0tOtUW1JIAZeEYwAAeuzQwtYg==",
         "dependencies": {
-          "Endjin.RecommendedPractices": "2.1.2",
+          "Endjin.RecommendedPractices": "2.1.4",
           "Microsoft.SourceLink.GitHub": "1.1.1"
         }
       },
       "Roslynator.Analyzers": {
         "type": "Direct",
-        "requested": "[4.1.1, )",
-        "resolved": "4.1.1",
-        "contentHash": "3cPVlrB1PytlO1ztZZBOExDKQWpMZgI15ZDa0BqLu0l6xv+xIRfEpqjNRcpvUy3aLxWTkPgSKZbbaO+VoFEJ1g=="
+        "requested": "[4.2.0, )",
+        "resolved": "4.2.0",
+        "contentHash": "3N8CNx1Q/Q5VDDL7qgfZRgTURyMqzHAkAB59AZKRnsOXoh2n9xRzhiBMIbJaUtBATmieECBx68GcjRn2xoNDug=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",
@@ -68,8 +66,8 @@
       },
       "BenchmarkDotNet.Annotations": {
         "type": "Transitive",
-        "resolved": "0.13.2",
-        "contentHash": "+SGOYyXT6fiagbtrni38B8BqBgjruYKU3PfROI0lDIYo8jQ+APUmLKMEswK7zwR5fEOCrDmoAHSH6oykBkqPgA=="
+        "resolved": "0.13.4",
+        "contentHash": "bc2q4S7xvOrqh7qRaMGyDdHVv8SITtN4crx5neIU289ra+LaP+OAmHPXxCY2djrnguZ8kfDddyJSg30wt7DvKg=="
       },
       "CommandLineParser": {
         "type": "Transitive",
@@ -83,11 +81,16 @@
       },
       "Endjin.RecommendedPractices": {
         "type": "Transitive",
-        "resolved": "2.1.2",
-        "contentHash": "Nbj0WS3zVDD2wjfU2/nbkWIWS9Ljg8VN+SSpaCuf5lHBOIEb0Ra201lGcyJHtRHybAciz+hQA9lHj7TnG52qqw==",
+        "resolved": "2.1.4",
+        "contentHash": "3B8zpRU3LEwHNZvEU8NHhzFZKZDpVaI4sMhv8bXcEoLQhRvJiBKQ90hibZIz7veX1Zi9PXrsH11HzdZBQMmntQ==",
         "dependencies": {
           "Microsoft.Build.Tasks.Git": "1.1.1"
         }
+      },
+      "Gee.External.Capstone": {
+        "type": "Transitive",
+        "resolved": "2.3.0",
+        "contentHash": "2ap/rYmjtzCOT8hxrnEW/QeiOt+paD8iRrIcdKX0cxVwWLFa1e+JDBNeECakmccXrSFeBQuu5AV8SNkipFMMMw=="
       },
       "Iced": {
         "type": "Transitive",
@@ -210,8 +213,8 @@
       },
       "Microsoft.Extensions.ObjectPool": {
         "type": "Transitive",
-        "resolved": "7.0.0",
-        "contentHash": "udvKco0sAVgYGTBnHUb0tY9JQzJ/nPDiv/8PIyz69wl1AibeCDZOLVVI+6156dPfHmJH7ws5oUJRiW4ZmAvuuA=="
+        "resolved": "7.0.2",
+        "contentHash": "i1YHthDbI3Xy4Vy1wC2EP+Z/yDJjpv5ejxnPxQ4p7sC8jnpWVfR2/T23Iz9+lIz5aBSruu8dOChmwvUQ3qYXZw=="
       },
       "Microsoft.Extensions.Options": {
         "type": "Transitive",
@@ -707,8 +710,15 @@
       },
       "System.Reflection.Emit": {
         "type": "Transitive",
-        "resolved": "4.7.0",
-        "contentHash": "VR4kk8XLKebQ4MZuKuIni/7oh+QGFmZW3qORd1GvBq/8026OpW501SzT/oypwiQl4TvT8ErnReh/NzY9u+C6wQ=="
+        "resolved": "4.0.1",
+        "contentHash": "P2wqAj72fFjpP6wb9nSfDqNBMab+2ovzSDzUZK7MVIm54tBJEPr9jWfSjjoTpPwj1LeKcmX3vr0ttyjSSFM47g==",
+        "dependencies": {
+          "System.IO": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Runtime": "4.1.0"
+        }
       },
       "System.Reflection.Emit.ILGeneration": {
         "type": "Transitive",
@@ -722,8 +732,14 @@
       },
       "System.Reflection.Emit.Lightweight": {
         "type": "Transitive",
-        "resolved": "4.7.0",
-        "contentHash": "a4OLB4IITxAXJeV74MDx49Oq2+PsF6Sml54XAFv+2RyWwtDBcabzoxiiJRhdhx+gaohLh4hEGCLQyBozXoQPqA=="
+        "resolved": "4.0.1",
+        "contentHash": "sSzHHXueZ5Uh0OLpUQprhr+ZYJrLPA2Cmr4gn0wj9+FftNKXx8RIMKvO9qnjk2ebPYUjZ+F2ulGdPOsvj+MEjA==",
+        "dependencies": {
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Runtime": "4.1.0"
+        }
       },
       "System.Reflection.Extensions": {
         "type": "Transitive",
@@ -1024,8 +1040,8 @@
       },
       "System.Text.Json": {
         "type": "Transitive",
-        "resolved": "7.0.0",
-        "contentHash": "DaGSsVqKsn/ia6RG8frjwmJonfos0srquhw09TlT8KRw5I43E+4gs+/bZj4K0vShJ5H9imCuXupb4RmS+dBy3w==",
+        "resolved": "7.0.1",
+        "contentHash": "OtDEmCCiNl8JAduFKZ/r0Sw6XZNHwIicUYy/mXgMDGeOsZLshH37qi3oPRzFYiryVktiMoQLByMGPtRCEMYbeQ==",
         "dependencies": {
           "System.Text.Encodings.Web": "7.0.0"
         }
@@ -1064,8 +1080,8 @@
       },
       "System.Threading.Tasks.Extensions": {
         "type": "Transitive",
-        "resolved": "4.5.4",
-        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg=="
+        "resolved": "4.5.0",
+        "contentHash": "csAJe24tWCOTO/rXoJAuBGuOq7ZdHY60XtC6b/hNMHT9tuX+2J9HK7nciLEtNvnrRLMxBACLXO3R4y5+kCduMA=="
       },
       "System.Threading.Timer": {
         "type": "Transitive",
@@ -1122,7 +1138,7 @@
         "type": "Project",
         "dependencies": {
           "CommunityToolkit.HighPerformance": "[8.0.0, )",
-          "Microsoft.Extensions.ObjectPool": "[7.0.0, )",
+          "Microsoft.Extensions.ObjectPool": "[7.0.2, )",
           "System.Buffers": "[4.5.1, )",
           "System.Collections.Immutable": "[7.0.0, )"
         }
@@ -1132,19 +1148,9 @@
         "dependencies": {
           "CommunityToolkit.HighPerformance": "[8.0.0, )",
           "Corvus.UriTemplates": "[1.0.0, )",
-          "Microsoft.Extensions.ObjectPool": "[7.0.0, )",
+          "Microsoft.Extensions.ObjectPool": "[7.0.2, )",
           "System.Buffers": "[4.5.1, )",
           "System.Collections.Immutable": "[7.0.0, )"
-        }
-      },
-      "corvus.uritemplates.resolvers.dictionaryofobject": {
-        "type": "Project",
-        "dependencies": {
-          "CommunityToolkit.HighPerformance": "[8.0.0, )",
-          "Corvus.UriTemplates": "[1.0.0, )",
-          "Microsoft.Extensions.ObjectPool": "[7.0.0-rc.1.22427.2, )",
-          "System.Buffers": "[4.5.1, )",
-          "System.Collections.Immutable": "[7.0.0-rc.1.22426.10, )"
         }
       },
       "corvus.uritemplates.resolvers.json": {
@@ -1152,10 +1158,10 @@
         "dependencies": {
           "CommunityToolkit.HighPerformance": "[8.0.0, )",
           "Corvus.UriTemplates": "[1.0.0, )",
-          "Microsoft.Extensions.ObjectPool": "[7.0.0, )",
+          "Microsoft.Extensions.ObjectPool": "[7.0.2, )",
           "System.Buffers": "[4.5.1, )",
           "System.Collections.Immutable": "[7.0.0, )",
-          "System.Text.Json": "[7.0.0, )"
+          "System.Text.Json": "[7.0.1, )"
         }
       }
     }

--- a/Solutions/Corvus.UriTemplate.TavisApi.Tests/.editorconfig
+++ b/Solutions/Corvus.UriTemplate.TavisApi.Tests/.editorconfig
@@ -1,0 +1,11 @@
+﻿# C# files
+[*.{cs,csx}]
+# Style - implicit and explicit types
+
+csharp_style_var_for_built_in_types = disable
+csharp_style_var_when_type_is_apparent = disable
+csharp_style_var_elsewhere = disable
+
+
+# Style - using directives and namespace declarations
+csharp_style_namespace_declarations = block_scoped:suggestion

--- a/Solutions/Corvus.UriTemplate.TavisApi.Tests/UriTemplateTests.csproj
+++ b/Solutions/Corvus.UriTemplate.TavisApi.Tests/UriTemplateTests.csproj
@@ -3,6 +3,15 @@
 	<PropertyGroup>
 		<TargetFrameworks>net6.0;net7.0</TargetFrameworks>
 		<IsPackable>false</IsPackable>
+
+    <!--
+    This project contains exact copies of specs from:
+			https://github.com/tavis-software/Tavis.UriTemplates/blob/master/src/UriTemplateTests/ParameterMatchingTests.cs
+    (as permissible under the Apache license).
+    That code does not conform to our coding style, so we need to disable a few warnings.
+    (We also have a local .editorconfig, but not everything can be handled through that.)
+    -->
+    <NoWarn>$(NoWarn);RCS1163;CA1825;IDE0017;IDE0059;IDE0062;IDE0090;IDE0220;IDE1006;xUnit1004</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Solutions/Corvus.UriTemplates.Resolvers.DictionaryOfObject/Corvus.UriTemplates/DictionaryUriTemplateResolver.cs
+++ b/Solutions/Corvus.UriTemplates.Resolvers.DictionaryOfObject/Corvus.UriTemplates/DictionaryUriTemplateResolver.cs
@@ -95,8 +95,10 @@ public static class DictionaryUriTemplateResolver
         return UriTemplateResolver<DictionaryTemplateParameterProvider, IDictionary<string, object?>>.TryResolveResult(template, true, EmptyDictionary, Nop, callback, ref state);
 #endif
 
+#pragma warning disable RCS1163 // Unused parameter.
         static void Nop(ReadOnlySpan<char> value, ref TState state)
         {
+#pragma warning restore RCS1163 // Unused parameter.
         }
     }
 }

--- a/Solutions/Corvus.UriTemplates.Resolvers.Json/Corvus.UriTemplates/JsonUriTemplateResolver.cs
+++ b/Solutions/Corvus.UriTemplates.Resolvers.Json/Corvus.UriTemplates/JsonUriTemplateResolver.cs
@@ -95,8 +95,10 @@ public static class JsonUriTemplateResolver
         return UriTemplateResolver<JsonTemplateParameterProvider, JsonElement>.TryResolveResult(template, true, default, Nop, callback, ref state);
 #endif
 
+#pragma warning disable RCS1163 // Unused parameter.
         static void Nop(ReadOnlySpan<char> value, ref TState state)
         {
+#pragma warning restore RCS1163 // Unused parameter.
         }
     }
 }

--- a/Solutions/Corvus.UriTemplates.sln
+++ b/Solutions/Corvus.UriTemplates.sln
@@ -13,7 +13,15 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Corvus.UriTemplates.Resolve
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Corvus.UriTemplates.Resolvers.DictionaryOfObject", "Corvus.UriTemplates.Resolvers.DictionaryOfObject\Corvus.UriTemplates.Resolvers.DictionaryOfObject.csproj", "{C77AE102-65C4-4C64-8B53-B2476EC80280}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sandbox", "Sandbox\Sandbox.csproj", "{302F8634-2171-43DB-B5DD-5B01BE6026C2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sandbox", "Sandbox\Sandbox.csproj", "{302F8634-2171-43DB-B5DD-5B01BE6026C2}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "DevOps", "DevOps", "{A903B615-2FB5-40CB-958E-CC3C2294A931}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+		..\.gitignore = ..\.gitignore
+		..\azure-pipelines.yml = ..\azure-pipelines.yml
+		..\GitVersion.yml = ..\GitVersion.yml
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Solutions/Corvus.UriTemplates/Corvus.UriTemplates/TavisApi/DictionaryUriTemplateResolver.cs
+++ b/Solutions/Corvus.UriTemplates/Corvus.UriTemplates/TavisApi/DictionaryUriTemplateResolver.cs
@@ -95,8 +95,10 @@ internal static class DictionaryUriTemplateResolver
         return UriTemplateResolver<DictionaryTemplateParameterProvider, IDictionary<string, object?>>.TryResolveResult(template, true, EmptyDictionary, Nop, callback, ref state);
 #endif
 
+#pragma warning disable RCS1163 // Unused parameter.
         static void Nop(ReadOnlySpan<char> value, ref TState state)
         {
+#pragma warning restore RCS1163 // Unused parameter.
         }
     }
 }

--- a/Solutions/Corvus.UriTemplates/Corvus.UriTemplates/TavisApi/UriTemplate.cs
+++ b/Solutions/Corvus.UriTemplates/Corvus.UriTemplates/TavisApi/UriTemplate.cs
@@ -14,7 +14,7 @@ namespace Corvus.UriTemplates.TavisApi;
 /// </summary>
 public class UriTemplate
 {
-    private static readonly Uri ComponentBaseUri = new Uri("https://localhost.com", UriKind.Absolute);
+    private static readonly Uri ComponentBaseUri = new("https://localhost.com", UriKind.Absolute);
     private readonly object lockObject = new();
     private readonly string template;
     private readonly Dictionary<string, object?> parameters;

--- a/Solutions/Corvus.UriTemplates/Corvus.UriTemplates/TavisApi/UriTemplateExtensions.cs
+++ b/Solutions/Corvus.UriTemplates/Corvus.UriTemplates/TavisApi/UriTemplateExtensions.cs
@@ -58,8 +58,7 @@ public static class UriTemplateExtensions
     {
         if (parametersObject != null)
         {
-            IEnumerable<PropertyInfo> properties;
-            properties = parametersObject.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance);
+            IEnumerable<PropertyInfo> properties = parametersObject.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance);
             foreach (PropertyInfo propinfo in properties)
             {
                 template.SetParameter(propinfo.Name, propinfo.GetValue(parametersObject, null));

--- a/Solutions/Corvus.UriTemplates/Corvus.UriTemplates/TavisApi/UriTemplateTable.cs
+++ b/Solutions/Corvus.UriTemplates/Corvus.UriTemplates/TavisApi/UriTemplateTable.cs
@@ -9,7 +9,7 @@ namespace Corvus.UriTemplates.TavisApi;
 /// </summary>
 public class UriTemplateTable
 {
-    private readonly Dictionary<string, UriTemplate> templates = new Dictionary<string, UriTemplate>();
+    private readonly Dictionary<string, UriTemplate> templates = new();
 
     /// <summary>
     /// Get the URI template with the specified key.
@@ -20,8 +20,7 @@ public class UriTemplateTable
     {
         get
         {
-            UriTemplate? value;
-            if (this.templates.TryGetValue(key, out value))
+            if (this.templates.TryGetValue(key, out UriTemplate? value))
             {
                 return value;
             }

--- a/Solutions/Corvus.UriTemplates/Corvus.UriTemplates/UriTemplateParserFactory.cs
+++ b/Solutions/Corvus.UriTemplates/Corvus.UriTemplates/UriTemplateParserFactory.cs
@@ -162,7 +162,7 @@ public static class UriTemplateParserFactory
         }
     }
 
-    private ref struct Consumer
+    private readonly ref struct Consumer
     {
         private readonly ReadOnlySpan<IUriTemplatePatternElement> elements;
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,6 +22,6 @@ jobs:
     service_connection_github: $(Endjin_Service_Connection_GitHub)
     solution_to_build: $(Endjin_Solution_To_Build)
     additionalNetSdkVersions:
-    - '7.x'
+    - '7.0.103' # Until https://github.com/endjin/Endjin.RecommendedPractices.Build/issues/69 is fixed, we have to use an old SDK
     includeNetSdkPreviewVersions: 'true'
     compileTasksServiceConnection: endjin-acr-reader


### PR DESCRIPTION
Although builds were clean, a load of warnings and messages pop up when you open in VS...although only after a delay (and sometimes only when you open files).

This resolves those.