### PR TITLE
Remove nullability where not appropriate

### DIFF
--- a/Solutions/Corvus.UriTemplate.Benchmarking/UriTemplateParameterExtraction.cs
+++ b/Solutions/Corvus.UriTemplate.Benchmarking/UriTemplateParameterExtraction.cs
@@ -64,7 +64,7 @@ public class UriTemplateParameterExtraction
     /// A result, to ensure that the code under test does not get optimized out of existence.
     /// </returns>
     [Benchmark]
-    public IDictionary<string, object?>? ExtractParametersCorvusTavis()
+    public IDictionary<string, object>? ExtractParametersCorvusTavis()
     {
         return this.corvusTavisTemplate!.GetParameters(TavisUri);
     }

--- a/Solutions/Corvus.UriTemplate.Benchmarking/UriTemplateParameterSetting.cs
+++ b/Solutions/Corvus.UriTemplate.Benchmarking/UriTemplateParameterSetting.cs
@@ -15,7 +15,7 @@ public class UriTemplateParameterSetting
 {
     private const string UriTemplate = "http://example.org/location{?value*}";
     private static readonly Dictionary<string, string> Value = new() { { "foo", "bar" }, { "bar", "baz" }, { "baz", "bob" } };
-    private static readonly Dictionary<string, object?> Parameters = new() { { "value", Value } };
+    private static readonly Dictionary<string, object?> InputParameters = new() { { "value", Value } };
 
     private readonly JsonDocument jsonValues = JsonDocument.Parse("{\"value\": { \"foo\": \"bar\", \"bar\": \"baz\", \"baz\": \"bob\" }}");
     private Tavis.UriTemplates.UriTemplate? tavisTemplate;
@@ -87,7 +87,7 @@ public class UriTemplateParameterSetting
     public void ResolveUriCorvusDictionary()
     {
         object? nullState = default;
-        DictionaryUriTemplateResolver.TryResolveResult(UriTemplate.AsSpan(), false, Parameters, HandleResult, ref nullState);
+        DictionaryUriTemplateResolver.TryResolveResult(UriTemplate.AsSpan(), false, InputParameters, HandleResult, ref nullState);
 #pragma warning disable RCS1163 // Unused parameter.
         static void HandleResult(ReadOnlySpan<char> resolvedTemplate, ref object? state)
 #pragma warning restore RCS1163 // Unused parameter.

--- a/Solutions/Corvus.UriTemplates/Corvus.UriTemplates/TavisApi/TemplateMatch.cs
+++ b/Solutions/Corvus.UriTemplates/Corvus.UriTemplates/TavisApi/TemplateMatch.cs
@@ -22,5 +22,5 @@ public class TemplateMatch
     /// <summary>
     /// Gets or sets the matched parameters.
     /// </summary>
-    public IDictionary<string, object?>? Parameters { get; set; }
+    public IDictionary<string, object>? Parameters { get; set; }
 }

--- a/Solutions/Corvus.UriTemplates/Corvus.UriTemplates/TavisApi/UriExtensions.cs
+++ b/Solutions/Corvus.UriTemplates/Corvus.UriTemplates/TavisApi/UriExtensions.cs
@@ -38,8 +38,8 @@ public static partial class UriExtensions
     /// <returns>The URI template, with templatized query string, and parameters populated from the values in the query string.</returns>
     public static UriTemplate MakeTemplate(this Uri uri)
     {
-        Dictionary<string, object?> parameters = uri.GetQueryStringParameters();
-        return uri.MakeTemplate(parameters);
+        Dictionary<string, object> parameters = uri.GetQueryStringParameters();
+        return uri.MakeTemplate((IDictionary<string, object?>)parameters);
     }
 
     /// <summary>
@@ -63,19 +63,19 @@ public static partial class UriExtensions
     }
 
     /// <summary>
-    /// Get the query sstring parameters from the given URI.
+    /// Get the query string parameters from the given URI.
     /// </summary>
     /// <param name="target">The target URI for which to recover the query string parameters.</param>
     /// <returns>A map of the query string parameters.</returns>
-    public static Dictionary<string, object?> GetQueryStringParameters(this Uri target)
+    public static Dictionary<string, object> GetQueryStringParameters(this Uri target)
     {
-        Dictionary<string, object?> parameters = new();
+        Dictionary<string, object> parameters = new();
 
         GetQueryStringParameters(target, AccumulateResults, ref parameters);
 
         return parameters;
 
-        static void AccumulateResults(ReadOnlySpan<char> name, ReadOnlySpan<char> value, ref Dictionary<string, object?> state)
+        static void AccumulateResults(ReadOnlySpan<char> name, ReadOnlySpan<char> value, ref Dictionary<string, object> state)
         {
             state.Add(name.ToString(), value.ToString());
         }

--- a/Solutions/Corvus.UriTemplates/Corvus.UriTemplates/TavisApi/UriTemplate.cs
+++ b/Solutions/Corvus.UriTemplates/Corvus.UriTemplates/TavisApi/UriTemplate.cs
@@ -154,7 +154,7 @@ public class UriTemplate
     /// <param name="uri">The URI from which to get the parameters.</param>
     /// <param name="order">Whether to apply strict or relaxed query parameter ordering.</param>
     /// <returns>The parameters decomposed from the Uri.</returns>
-    public IDictionary<string, object?>? GetParameters(Uri uri, QueryStringParameterOrder order = QueryStringParameterOrder.Strict)
+    public IDictionary<string, object>? GetParameters(Uri uri, QueryStringParameterOrder order = QueryStringParameterOrder.Strict)
     {
         switch (order)
         {
@@ -171,7 +171,7 @@ public class UriTemplate
                         }
                     }
 
-                    var parameters = new Dictionary<string, object?>();
+                    var parameters = new Dictionary<string, object>();
 
                     if (parser.ParseUri(uri.OriginalString.AsSpan(), AddResults, ref parameters))
                     {
@@ -182,7 +182,7 @@ public class UriTemplate
                         return null;
                     }
 
-                    static void AddResults(bool reset, ReadOnlySpan<char> name, ReadOnlySpan<char> value, ref Dictionary<string, object?> results)
+                    static void AddResults(bool reset, ReadOnlySpan<char> name, ReadOnlySpan<char> value, ref Dictionary<string, object> results)
                     {
                         if (reset)
                         {
@@ -206,11 +206,11 @@ public class UriTemplate
                     string uriString = uri.GetComponents(UriComponents.SchemeAndServer | UriComponents.Path | UriComponents.Fragment, UriFormat.UriEscaped);
                     var uriWithoutQuery = new Uri(uriString, UriKind.Absolute);
 
-                    IDictionary<string, object?> pathParameters = this.GetParameters(uriWithoutQuery) ?? new Dictionary<string, object?>(this.parameters.Comparer);
+                    IDictionary<string, object> pathParameters = this.GetParameters(uriWithoutQuery) ?? new Dictionary<string, object>(this.parameters.Comparer);
 
                     HashSet<string> parameterNames = this.GetParameterNamesHashSet();
 
-                    (HashSet<string> ParameterNames, IDictionary<string, object?> PathParameters) parameterState = (parameterNames, pathParameters);
+                    (HashSet<string> ParameterNames, IDictionary<string, object> PathParameters) parameterState = (parameterNames, pathParameters);
 
                     uri.GetQueryStringParameters(MatchParameterNames, ref parameterState);
 
@@ -221,7 +221,7 @@ public class UriTemplate
                 throw new ArgumentOutOfRangeException(nameof(order), order, null);
         }
 
-        static void MatchParameterNames(ReadOnlySpan<char> name, ReadOnlySpan<char> value, ref (HashSet<string> ParameterNames, IDictionary<string, object?> PathParameters) state)
+        static void MatchParameterNames(ReadOnlySpan<char> name, ReadOnlySpan<char> value, ref (HashSet<string> ParameterNames, IDictionary<string, object> PathParameters) state)
         {
             string name1 = name.ToString();
             if (state.ParameterNames.Contains(name1))

--- a/Solutions/Corvus.UriTemplates/Corvus.UriTemplates/TavisApi/UriTemplateTable.cs
+++ b/Solutions/Corvus.UriTemplates/Corvus.UriTemplates/TavisApi/UriTemplateTable.cs
@@ -51,7 +51,7 @@ public class UriTemplateTable
     {
         foreach (KeyValuePair<string, UriTemplate> template in this.templates)
         {
-            IDictionary<string, object?>? parameters = template.Value.GetParameters(url, order);
+            IDictionary<string, object>? parameters = template.Value.GetParameters(url, order);
             if (parameters != null)
             {
                 return new TemplateMatch() { Key = template.Key, Parameters = parameters, Template = template.Value };


### PR DESCRIPTION
Resolves #50 

The Tavis API makes somewhat fuzzy use of the term "parameter", and in some cases a parameter value is allowed to be null, but in cases where it reports the 'parameters' that are present in a particular URL as interpretted through a particular template, it will never report null values. (It provides a dictionary containing only those values that were present, so there's no occasion for this to have null values.)

This was not reflected in the API - it used IDictionary<string, object?> even in cases where the value would not be null. This change corrects that.