### PR TITLE
Remove refs to analyzers implied by Endjin.RecommendedPractices

### DIFF
--- a/Solutions/Corvus.UriTemplate.Benchmarking/Corvus.UriTemplate.Benchmarking.csproj
+++ b/Solutions/Corvus.UriTemplate.Benchmarking/Corvus.UriTemplate.Benchmarking.csproj
@@ -37,8 +37,4 @@
 		<RestoreLockedMode Condition="$(ContinuousIntegrationBuild) == 'true'">true</RestoreLockedMode>
 	</PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Update="Roslynator.Analyzers" Version="4.2.0" />
-	</ItemGroup>
-
 </Project>

--- a/Solutions/Corvus.UriTemplates.Resolvers.DictionaryOfObject/Corvus.UriTemplates.Resolvers.DictionaryOfObject.csproj
+++ b/Solutions/Corvus.UriTemplates.Resolvers.DictionaryOfObject/Corvus.UriTemplates.Resolvers.DictionaryOfObject.csproj
@@ -27,12 +27,4 @@
 		<ProjectReference Include="..\Corvus.UriTemplates\Corvus.UriTemplates.csproj" />
 	</ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<PackageReference Update="Roslynator.Analyzers" Version="4.2.0" />
-	</ItemGroup>
-
 </Project>

--- a/Solutions/Corvus.UriTemplates.Resolvers.Json/Corvus.UriTemplates.Resolvers.Json.csproj
+++ b/Solutions/Corvus.UriTemplates.Resolvers.Json/Corvus.UriTemplates.Resolvers.Json.csproj
@@ -28,12 +28,4 @@
 	  <ProjectReference Include="..\Corvus.UriTemplates\Corvus.UriTemplates.csproj" />
 	</ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<PackageReference Update="Roslynator.Analyzers" Version="4.2.0" />
-	</ItemGroup>
-
 </Project>

--- a/Solutions/Corvus.UriTemplates/Corvus.UriTemplates.csproj
+++ b/Solutions/Corvus.UriTemplates/Corvus.UriTemplates.csproj
@@ -23,12 +23,4 @@
 		<PackageReference Include="Microsoft.Extensions.ObjectPool" Version="7.0.5" />
 	</ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<PackageReference Update="Roslynator.Analyzers" Version="4.2.0" />
-	</ItemGroup>
-
 </Project>


### PR DESCRIPTION
Several projects had ended up with explicit references to Roslynator.Analyzers and StyleCop.Analyzers. These are unnecessary because Endjin.RecommendedPractices includes them automatically.

(This usually happens when those analyzer packages get updated - the NuGet explorer doesn't understand that they've come in via Endjin.RecommendPractices, because transient build-time dependencies aren't really a thing in NuGet so we had to employ a hack to make that work in Endjin.RecommendedPractices. NuGet spuriously offers to update the refs for you, at which point you end up with explicit references.)